### PR TITLE
remove 'public' in build procedures, readme / contributing and elsewhere previously missed before

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## How are collections added to the registry?
 
-Each collection in this repository is described in a dedicated YAML file stored in [./collections](https://github.com/sentinel-hub/public-collections/tree/main/collections) directory, e.g. /collections/global-land-cover.yaml.  
+Each collection in this repository is described in a dedicated YAML file stored in [./collections](https://github.com/sentinel-hub/collections/tree/main/collections) directory, e.g. /collections/global-land-cover.yaml.  
 Data providers can create a new YAML file copying the structure of the most similar existing one. After committing it to the GitHub, create a pull request and Sentinel Hub team will review it and publish it in the Registry.  
 Note that for additional external files e.g the thumbnail image to be displayed correctly , store it in a directory that is named similar to the associated YAML file. 
 Users are also welcome to revise existing collections, e.g. adding new usage examples , tools, etc.  
@@ -14,7 +14,7 @@ Users are also welcome to revise existing collections, e.g. adding new usage exa
 | Field | Type | Description & Style |
 | --- | --- | --- |
 | **Name** | String | Full name of the collection.|
-| **Description**|MD|A high-level description of the collection. Only the first 600 characters will be displayed on the homepage of the [Sentinel Hub Public Collections](https://collections.sentinel-hub.com/).|
+| **Description**|MD|A high-level description of the collection. Only the first 600 characters will be displayed on the homepage of the [Sentinel Hub Collections](https://collections.sentinel-hub.com/).|
  **Documentation**|MD| A link to documentation of the collection on the data provider's website.|
 |**AdditionalInfoExternal**|| Additional documentation of the collection contained in a README.MD file saved in this repository.|
 |**AdditionalInfoExternal >> Title**|String| Title,  default = 'Additional Info' |
@@ -51,8 +51,8 @@ Users are also welcome to revise existing collections, e.g. adding new usage exa
 </details>
 
 
-## How to build Sentinel Hub Public Collections website locally
-You can build the Sentinel Hub Public Collections website locally, to preview and test your changes before submitting a merge request. Below is a step-by-step guide to build the site locally.
+## How to build Sentinel Hub Collections website locally
+You can build the Sentinel Hub Collections website locally, to preview and test your changes before submitting a merge request. Below is a step-by-step guide to build the site locally.
 
 
 <details> 
@@ -67,7 +67,7 @@ You can build the Sentinel Hub Public Collections website locally, to preview an
    <li>Create a .env file with the following content in the repository.
 
    ```
-   GIT_HUB_COLLECTIONS_REPO=sentinel-hub/public-collections
+   GIT_HUB_COLLECTIONS_REPO=sentinel-hub/collections
    GIT_HUB_COLLECTIONS_BRANCH=main
    COLLECTIONS_BROWSER_ROOT_URL="http://localhost:3000/"
    ```
@@ -96,7 +96,7 @@ You can build the Sentinel Hub Public Collections website locally, to preview an
    <li>Create a .env file with the following content in the repository.
 
    ```
-   GIT_HUB_COLLECTIONS_REPO=sentinel-hub/public-collections
+   GIT_HUB_COLLECTIONS_REPO=sentinel-hub/collections
    GIT_HUB_COLLECTIONS_BRANCH=main
    COLLECTIONS_BROWSER_ROOT_URL="http://localhost:3000/"
    ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sentinel Hub Public Collections
+# Sentinel Hub Collections
 
 A repository of publicly available collections that are available for access through [Sentinel Hub](https://www.sentinel-hub.com/). Note that collections in this registry are available via Sentinel Hub, but owned and maintained by different providers.
 

--- a/examples/how_to_access_public_collections.ipynb
+++ b/examples/how_to_access_public_collections.ipynb
@@ -89,7 +89,7 @@
    "metadata": {},
    "source": [
     "## The Sentinels, Landsat, DEM and MODIS Collections\n",
-    "The Sentinels, Landsat, DEM and MODIS collections have been predefined in sentinelhub py `DataCollection` class. On [Sentinel Hub Public Collections](https://collections.sentinel-hub.com/) page, these collections' `Type` starts without `byoc-`. E.g., [Copernicus DEM](https://collections.sentinel-hub.com/copernicus-dem/), [Landsat-8 L1](https://collections.sentinel-hub.com/landsat-8-l1/), [Sentinel-1 GRD](https://collections.sentinel-hub.com/sentinel-1-grd/), [Sentinel-2 L2A](https://collections.sentinel-hub.com/sentinel-2-l2a/) etc. Please refer to the [DataCollection documentation](https://sentinelhub-py.readthedocs.io/en/latest/reference/sentinelhub.data_collections.html#sentinelhub.data_collections.DataCollection) for the corresponding attributes of `DataCollection` based on the `Type` listed on the page."
+    "The Sentinels, Landsat, DEM and MODIS collections have been predefined in sentinelhub py `DataCollection` class. On [Sentinel Hub Collections](https://collections.sentinel-hub.com/) page, these collections' `Type` starts without `byoc-`. E.g., [Copernicus DEM](https://collections.sentinel-hub.com/copernicus-dem/), [Landsat-8 L1](https://collections.sentinel-hub.com/landsat-8-l1/), [Sentinel-1 GRD](https://collections.sentinel-hub.com/sentinel-1-grd/), [Sentinel-2 L2A](https://collections.sentinel-hub.com/sentinel-2-l2a/) etc. Please refer to the [DataCollection documentation](https://sentinelhub-py.readthedocs.io/en/latest/reference/sentinelhub.data_collections.html#sentinelhub.data_collections.DataCollection) for the corresponding attributes of `DataCollection` based on the `Type` listed on the page."
    ]
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "open-data-registry-browser",
   "version": "0.0.1",
-  "description": "Browser for https://github.com/sentinel-hub/public-collections",
+  "description": "Browser for https://github.com/sentinel-hub/collections",
   "main": "gulpfile.js",
   "scripts": {
     "build": "./node_modules/gulp-cli/bin/gulp.js",
@@ -10,7 +10,7 @@
   "author": "Joe Flasher",
   "license": "Apache-2.0",
   "private": false,
-  "repository": "https://github.com/sentinel-hub/public-collections",
+  "repository": "https://github.com/sentinel-hub/collections",
   "devDependencies": {
     "browser-sync": "^2.26.14",
     "del": "^3.0.0",


### PR DESCRIPTION
part of [this issue](https://hello.planet.com/code/sentinel-hub/sentinel-frontend/eo-browser/eobrowser3/-/issues/1424)