### PR TITLE
Fix - update R&B highlights to use correct layerId

### DIFF
--- a/collections/road-and-building-detection/sandbox-data.md
+++ b/collections/road-and-building-detection/sandbox-data.md
@@ -41,36 +41,36 @@ To purchase data over your own areas and times of interest, <a href="https://www
 
 <div class="container33">
     <div class="image-card">
-    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-6.64342&lng=-51.97589&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_BRA.png" alt="EOB Highlight 1" class="imagette"></a>
+    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-6.64342&lng=-51.97589&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_BRA.png" alt="EOB Highlight 1" class="imagette"></a>
         <div class="info">
             <div class="title">São Félix do Xingu, Brazil</div>
             <div class="text">
                 2021-01-01 to 2023-03-01<br>
                 27020km<sup>2</sup>
             </div>
-            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-6.64342&lng=-51.97589&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
+            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-6.64342&lng=-51.97589&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
         </div>
     </div>
     <div class="image-card">
-    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=29.94687&lng=31.63204&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_EGY.png" alt="EOB Highlight 2" class="imagette"></a>
+    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=29.94687&lng=31.63204&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_EGY.png" alt="EOB Highlight 2" class="imagette"></a>
         <div class="info">
             <div class="title">Cairo, Egypt</div>
             <div class="text">
                 2021-01-01 to 2023-03-01<br>
                 13962km<sup>2</sup>
             </div>
-            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=29.94687&lng=31.63204&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
+            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=29.94687&lng=31.63204&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
         </div>
     </div>
     <div class="image-card">
-    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-31.94761&lng=115.86455&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_AUS.png" alt="EOB Highlight 3" class="imagette"></a>
+    <a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-31.94761&lng=115.86455&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank"><img src="RNB_AUS.png" alt="EOB Highlight 3" class="imagette"></a>
         <div class="info">
             <div class="title">Perth, Australia</div>
             <div class="text">
                 2021-01-01 to 2023-03-01<br>
                 29827km<sup>2</sup>
             </div>
-            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-31.94761&lng=115.86455&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
+            <div class="eob-link"><a href='https://apps.sentinel-hub.com/eo-browser/?zoom=14&lat=-31.94761&lng=115.86455&themeId=PLANET_SANDBOX&visualizationUrl=https%3A%2F%2Fservices.sentinel-hub.com%2Fogc%2Fwms%2F655dfaa9-35e3-4fe1-a8e2-14e4c178f6b9&datasetId=9ff30ab7-62c2-4d19-b5ef-83805c7e7602&fromTime=2023-03-01T00%3A00%3A00.000Z&toTime=2023-03-01T23%3A59%3A59.999Z&layerId=0-ROADS-AND-BUILDINGS&demSource3D="MAPZEN"' target="_blank">Visualise in EO Browser -></a></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
The order of the layers was changed in EOB, pushing  R&B to the first place by changing it's layerId, thus the changes needed here

Testing link: https://devext-fe.sinergise.com/sh-collections/tmp/fix/road-and-building-highlights/road-and-building-detection/sandbox-data.html