### PR TITLE
add Trial access for Planet Sandbox data

### DIFF
--- a/_build/partials/sandbox_about.hbs
+++ b/_build/partials/sandbox_about.hbs
@@ -4,7 +4,7 @@
       Planet Sandbox Data
       <img id="sandbox-planet-logo" src="{{rootUrl}}img/logos/planet-logo.svg" alt="">
     </h1>
-    <p> Test and experience a substantial amount of <a href="https://www.planet.com/" target="_blank">Planet</a> data samples made available under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC</a> license to all active Planet users and Sentinel Hub users with a paid subscription. Sandbox Data offers a subset of the <a href="https://worldstrat.github.io/" target="_blank">WorldStrat</a> locations and dense time-stacks, ranging from 25 to 200 km<sup>2</sup> in size. The locations are spread across the world, assuring a stratified representation of various use cases.</p>
+    <p> Test and experience a substantial amount of <a href="https://www.planet.com/" target="_blank">Planet</a> data samples made available under a <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC</a> license to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. Sandbox Data offers a subset of the <a href="https://worldstrat.github.io/" target="_blank">WorldStrat</a> locations and dense time-stacks, ranging from 25 to 200 km<sup>2</sup> in size. The locations are spread across the world, assuring a stratified representation of various use cases.</p>
     <hr>
      <div>
         <p>
@@ -34,6 +34,6 @@
         </h5>
       </div>
     </a>
-    <p class="explore-btn-footer">*Available for all active Planet users and Sentinel Hub users with a paid subscription.</p>
+    <p class="explore-btn-footer">*Available for all active Planet users and Sentinel Hub users with a paid subscription or a Trial account.</p>
   </div>
 </div>

--- a/collections/analysis-ready-planetscope.yaml
+++ b/collections/analysis-ready-planetscope.yaml
@@ -6,7 +6,7 @@ Description: |
   Limit storage and compute costs by working with only the data you need before delivering data to your preferred GIS, data science, remote sensing, or software environments via API or OGC streaming services.
 Image: analysis-ready-planetscope/analysis-ready-planetscope.png
 SandboxData: |
-  Discover samples of Analysis-Ready PlanetScope, free to all active Planet users and Sentinel Hub users with a paid subscription. [Sandbox Data for Analysis-Ready PlanetScope](sandbox-data.html)
+  Discover samples of Analysis-Ready PlanetScope, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. [Sandbox Data for Analysis-Ready PlanetScope](sandbox-data.html)
 Resolution: 3 meters
 GeographicalCoverage: Land surface area (<a href="https://www.planet.com/products/planet-imagery/" target="_blank">more info</a>)
 TemporalAvailability: January 01, 2018 - Present

--- a/collections/analysis-ready-planetscope/sandbox-data.md
+++ b/collections/analysis-ready-planetscope/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Analysis-Ready PlanetScope Sandbox Data
 
-<p> This sandbox collection of  <a href="../analysis-ready-planetscope/">Analysis-Ready Planetscope</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC-BY-NC license.</a></p>
+<p> This sandbox collection of  <a href="../analysis-ready-planetscope/">Analysis-Ready Planetscope</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/">CC-BY-NC license.</a></p>
 
 ### Collections
 

--- a/collections/forest-carbon-diligence.yaml
+++ b/collections/forest-carbon-diligence.yaml
@@ -6,7 +6,7 @@ Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/forest-carbon-diligence/" target="_blank">Sentinel Hub Documentation for Forest Carbon Diligence</a><br>
   <a href="https://developers.planet.com/docs/planetary-variables/forest-carbon-diligence/" target="_blank">Product Website for Forest Carbon Diligence</a>
 SandboxData: |
-  Discover samples of Forest Carbon Diligence, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for Forest Carbon Diligence</a>
+  Discover samples of Forest Carbon Diligence, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Forest Carbon Diligence</a>
 Image: forest-carbon-diligence/forest-carbon-diligence.png
 Resolution: 30m
 GeographicalCoverage: Global

--- a/collections/forest-carbon-diligence/sandbox-data.md
+++ b/collections/forest-carbon-diligence/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Forest Carbon Diligence Sandbox Data
 
-This sandbox collection of <a href="../forest-carbon-diligence/">Forest Carbon Diligence</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This sandbox collection of <a href="../forest-carbon-diligence/">Forest Carbon Diligence</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 

--- a/collections/land-surface-temperature.yaml
+++ b/collections/land-surface-temperature.yaml
@@ -6,7 +6,7 @@ Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/land-surface-temp/" target="_blank">Sentinel Hub Documentation for Land Surface Temperature</a><br>
   <a href="https://developers.planet.com/docs/planetary-variables/land-surface-temperature" target="_blank">Product Website for Land Surface Temperature</a>
 SandboxData: |
-  Discover samples of Land Surface Temperature, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for Land Surface Temperature</a>
+  Discover samples of Land Surface Temperature, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Land Surface Temperature</a>
 Image: land-surface-temperature/land-surface-temperature.png
 Resolution: 100m and 1000m
 GeographicalCoverage: Global

--- a/collections/land-surface-temperature/sandbox-data.md
+++ b/collections/land-surface-temperature/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Land Surface Temperature Sandbox Data
 
-This Sandbox collection of <a href="../land-surface-temperature/">Land Surface Temperature</a> offers a limited area and time of interest. Only Planet users and Sentinel Hub users with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This Sandbox collection of <a href="../land-surface-temperature/">Land Surface Temperature</a> offers a limited area and time of interest. Only Planet users and Sentinel Hub users with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 

--- a/collections/planet-basemaps.yaml
+++ b/collections/planet-basemaps.yaml
@@ -6,7 +6,7 @@ Description: |
 Documentation: |
  <a href="https://www.planet.com/products/basemap/" target="_blank">Planet Basemaps Product Documentation</a>
 SandboxData: |
-  Discover samples of Basemaps, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for  Planet Basemaps</a>
+  Discover samples of Basemaps, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for  Planet Basemaps</a>
 Image: planet-basemaps/planet-basemaps.png
 Resolution: 4.77m at equator based on PlanetScope GSD
 GeographicalCoverage: Global between 74° N and 60° S (seasonally dependent)

--- a/collections/planet-basemaps/sandbox-data.md
+++ b/collections/planet-basemaps/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Planet Basemaps Sandbox Data
 
-This sandbox collection of <a href="../planet-basemaps/">Planet Basemaps</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This sandbox collection of <a href="../planet-basemaps/">Planet Basemaps</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 <table>

--- a/collections/planetscope.yaml
+++ b/collections/planetscope.yaml
@@ -7,7 +7,7 @@ Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planet/planet-scope/" target="_blank">Sentinel Hub Documentation for PlanetScope</a><br>
   <a href="https://developers.planet.com/docs/data/planetscope/" target="_blank">Product Website for PlanetScope</a>
 SandboxData: |
-  Discover samples of PlanetScope, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for PlanetScope</a>
+  Discover samples of PlanetScope, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for PlanetScope</a>
 Image: planetscope/planetscope.png
 Resolution: 3m
 GeographicalCoverage: Land surface area (<a href="https://www.planet.com/products/planet-imagery/" target="_blank">more info</a>)

--- a/collections/planetscope/sandbox-data.md
+++ b/collections/planetscope/sandbox-data.md
@@ -1,6 +1,6 @@
 ## PlanetScope Sandbox Data
 
-This sandbox collection of <a href="../planetscope/">PlanetScope</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>. 
+This sandbox collection of <a href="../planetscope/">PlanetScope</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>. 
 
 ### Collections
 <table>

--- a/collections/road-and-building-detection.yaml
+++ b/collections/road-and-building-detection.yaml
@@ -6,7 +6,7 @@ Description: |
 Documentation: |
   <a href="https://www.planet.com/products/analytics/" target="_blank">Planet Road and Building Detection Product Documentation</a>
 SandboxData: |
-  Discover samples of Road and Buiding Detection, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for Road and Building Detection</a>
+  Discover samples of Road and Buiding Detection, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Road and Building Detection</a>
 Image: road-and-building-detection/road-and-building-detection.png
 Resolution: 4.77m at equator based on PlanetScope GSD
 GeographicalCoverage: Global between 74° N and 60° S (seasonally dependent)

--- a/collections/road-and-building-detection/sandbox-data.md
+++ b/collections/road-and-building-detection/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Road and Building Detection Sandbox Data
 
-This sandbox collection of <a href="../road-and-building-detection/"> Road and Building Detection</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This sandbox collection of <a href="../road-and-building-detection/"> Road and Building Detection</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 

--- a/collections/skysat.yaml
+++ b/collections/skysat.yaml
@@ -9,7 +9,7 @@ Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planet/skysat/" target="_blank">Sentinel Hub Documentation for SkySat</a><br>
   <a href="https://developers.planet.com/docs/data/skysat/" target="_blank">Product Website for Skysat</a>
 SandboxData: |
-  Discover samples of SkySat, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for SkySat</a>
+  Discover samples of SkySat, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for SkySat</a>
 Image: skysat/skysat.png
 Resolution: 0.5m (resampled)
 GeographicalCoverage: Worldwide (<a href="https://www.planet.com/products/planet-imagery/" target="_blank">more info</a>)

--- a/collections/skysat/sandbox-data.md
+++ b/collections/skysat/sandbox-data.md
@@ -1,6 +1,6 @@
 ## SkySat Sandbox Data
 
-This sandbox collection of <a href="../skysat/">SkySat</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This sandbox collection of <a href="../skysat/">SkySat</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 <table>

--- a/collections/soil-water-content.yaml
+++ b/collections/soil-water-content.yaml
@@ -9,7 +9,7 @@ Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/soil-water-content/" target="_blank">Sentinel Hub Documentation for Soil Water Content</a><br>
   <a href="https://developers.planet.com/docs/planetary-variables/soil-water-content/" target="_blank">Product Website for Soil Water Content</a>
 SandboxData: |
-  Discover samples of Soil Water Content, free to all active Planet users and Sentinel Hub users with a paid subscription. <a href="sandbox-data.html">Sandbox Data for Soil Water Content</a>
+  Discover samples of Soil Water Content, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Soil Water Content</a>
 Image: soil-water-content/soil-water-content.png
 Resolution: 100m and 1000km
 GeographicalCoverage: Global

--- a/collections/soil-water-content/sandbox-data.md
+++ b/collections/soil-water-content/sandbox-data.md
@@ -1,6 +1,6 @@
 ## Soil Water Content Sandbox Data
 
-This sandbox collection of <a href="../soil-water-content/">Soil Water Content</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
+This sandbox collection of <a href="../soil-water-content/">Soil Water Content</a> offers a limited area and time of interest. Only Planet accounts and Sentinel Hub accounts with a paid subscription or a Trial account have access under the <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank">CC-BY-NC license</a>.
 
 ### Collections
 


### PR DESCRIPTION
Planet Sandbox data is being opened to Trial accounts. This PR updates the documentation for that.