### PR TITLE
Change Planet documentation links to docs.planet.com

### DIFF
--- a/collections/forest-carbon-diligence.yaml
+++ b/collections/forest-carbon-diligence.yaml
@@ -4,7 +4,7 @@ Description: |
   These data are collected annually over the entire land mass of the Earth (between 75° N and 60° S).
 Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/forest-carbon-diligence/" target="_blank">Sentinel Hub Documentation for Forest Carbon Diligence</a><br>
-  <a href="https://developers.planet.com/docs/planetary-variables/forest-carbon-diligence/" target="_blank">Product Website for Forest Carbon Diligence</a>
+  <a href="https://docs.planet.com/data/planetary-variables/forest-carbon-diligence/" target="_blank">Product Website for Forest Carbon Diligence</a>
 SandboxData: |
   Discover samples of Forest Carbon Diligence, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Forest Carbon Diligence</a>
 Image: forest-carbon-diligence/forest-carbon-diligence.png

--- a/collections/land-surface-temperature.yaml
+++ b/collections/land-surface-temperature.yaml
@@ -4,7 +4,7 @@ Description: |
   This Planetary Variable measures the temperature twice a day (daytime and nighttime) with a spatial resolution of 100 m and 1000 m, providing vital intelligence about our nexus food/water system, and urban living conditions.
 Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/land-surface-temp/" target="_blank">Sentinel Hub Documentation for Land Surface Temperature</a><br>
-  <a href="https://developers.planet.com/docs/planetary-variables/land-surface-temperature" target="_blank">Product Website for Land Surface Temperature</a>
+  <a href="https://docs.planet.com/data/planetary-variables/land-surface-temperature/" target="_blank">Product Website for Land Surface Temperature</a>
 SandboxData: |
   Discover samples of Land Surface Temperature, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Land Surface Temperature</a>
 Image: land-surface-temperature/land-surface-temperature.png

--- a/collections/planetscope.yaml
+++ b/collections/planetscope.yaml
@@ -5,7 +5,7 @@ Description: |
   Sentinel Hub offers the ability to purchase, order and access both the archive data and newly acquired data available globally since 2016. Sentinel Hub provides access to PlanetScope data in Top of the atmosphere (TOA) reflectance.
 Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planet/planet-scope/" target="_blank">Sentinel Hub Documentation for PlanetScope</a><br>
-  <a href="https://developers.planet.com/docs/data/planetscope/" target="_blank">Product Website for PlanetScope</a>
+  <a href="https://docs.planet.com/data/imagery/planetscope/" target="_blank">Product Website for PlanetScope</a>
 SandboxData: |
   Discover samples of PlanetScope, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for PlanetScope</a>
 Image: planetscope/planetscope.png

--- a/collections/skysat.yaml
+++ b/collections/skysat.yaml
@@ -7,7 +7,7 @@ Description: |
   Because of its rapid revisit time, these data are suitable for monitoring rapid changes on the Earth's surface. 
 Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planet/skysat/" target="_blank">Sentinel Hub Documentation for SkySat</a><br>
-  <a href="https://developers.planet.com/docs/data/skysat/" target="_blank">Product Website for Skysat</a>
+  <a href="https://docs.planet.com/data/imagery/skysat/" target="_blank">Product Website for Skysat</a>
 SandboxData: |
   Discover samples of SkySat, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for SkySat</a>
 Image: skysat/skysat.png

--- a/collections/soil-water-content.yaml
+++ b/collections/soil-water-content.yaml
@@ -7,7 +7,7 @@ Description: |
   It is not affected by clouds and has a long and consistent data record of more than 20 years, so there is no need to maintain large networks of physical sensors.
 Documentation: |
   <a href="https://docs.sentinel-hub.com/api/latest/data/planetary-variables/soil-water-content/" target="_blank">Sentinel Hub Documentation for Soil Water Content</a><br>
-  <a href="https://developers.planet.com/docs/planetary-variables/soil-water-content/" target="_blank">Product Website for Soil Water Content</a>
+  <a href="https://docs.planet.com/data/planetary-variables/soil-water-content/" target="_blank">Product Website for Soil Water Content</a>
 SandboxData: |
   Discover samples of Soil Water Content, free to all active Planet users and Sentinel Hub users with a paid subscription or a Trial account. <a href="sandbox-data.html">Sandbox Data for Soil Water Content</a>
 Image: soil-water-content/soil-water-content.png


### PR DESCRIPTION
This replaces links to https://developers.planet.com/ with equivalent links to https://docs.planet.com/. 